### PR TITLE
Template updates

### DIFF
--- a/backbone-component-template/test.js
+++ b/backbone-component-template/test.js
@@ -14,7 +14,7 @@ var test = require('tape')
     stopListening.restore()
   }
 
-test('{{PascalName}}: constructor', function(t){
+test('{{PascalName}}: constructor', function constructorTest(t){
   var view = createView()
 
   t.equal(
@@ -26,7 +26,7 @@ test('{{PascalName}}: constructor', function(t){
   t.end()
 })
 
-test('{{PascalName}}#bindEvents', function(t){
+test('{{PascalName}}#bindEvents', function bindEventsTest(t){
   var view = createView()
     , fn = view.bindEvents
 
@@ -48,7 +48,7 @@ test('{{PascalName}}#bindEvents', function(t){
   t.end()
 })
 
-test('{{PascalName}}#beforeInit', function(t){
+test('{{PascalName}}#beforeInit', function beforeInitTest(t){
   var view = createView()
     , fn = view.beforeInit
 
@@ -61,7 +61,7 @@ test('{{PascalName}}#beforeInit', function(t){
   t.end()
 })
 
-test('{{PascalName}}#context', function(t){
+test('{{PascalName}}#context', function contextTest(t){
   var view = createView()
     , fn = view.context
 

--- a/backbone-pane-template/pane-test.js
+++ b/backbone-pane-template/pane-test.js
@@ -14,7 +14,7 @@ var test = require('tape')
     stopListening.restore()
   }
 
-test('Pane: {{PascalName}}: constructor', function(t){
+test('Pane: {{PascalName}}: constructor', function constructorTest(t){
   var view = createView()
 
   t.equal(
@@ -26,7 +26,7 @@ test('Pane: {{PascalName}}: constructor', function(t){
   t.end()
 })
 
-test('Pane: {{PascalName}}#bindEvents', function (t){
+test('Pane: {{PascalName}}#bindEvents', function bindEventsTest(t){
   var view = createView()
     , fn = view.bindEvents
 
@@ -48,7 +48,7 @@ test('Pane: {{PascalName}}#bindEvents', function (t){
   t.end()
 })
 
-test('Pane: {{PascalName}}#beforeInit', function(t){
+test('Pane: {{PascalName}}#beforeInit', function beforeInitTest(t){
   var view = createView()
     , fn = view.beforeInit
     , options = defaultOptions
@@ -62,7 +62,7 @@ test('Pane: {{PascalName}}#beforeInit', function(t){
   t.end()
 })
 
-test('Pane: {{PascalName}} properties', function(t){
+test('Pane: {{PascalName}} properties', function propertiesTest(t){
   var view = createView()
 
   t.ok(

--- a/backbone-pane-template/pane-test.js
+++ b/backbone-pane-template/pane-test.js
@@ -51,7 +51,7 @@ test('Pane: {{PascalName}}#bindEvents', function (t){
 test('Pane: {{PascalName}}#beforeInit', function(t){
   var view = createView()
     , fn = view.beforeInit
-    , options = {}
+    , options = defaultOptions
 
   fn.call(view, options)
   t.ok(

--- a/backbone-pane-template/step-test.js
+++ b/backbone-pane-template/step-test.js
@@ -14,7 +14,7 @@ var test = require('tape')
     stopListening.restore()
   }
 
-test('Step: {{PascalName}}: constructor', function(t){
+test('Step: {{PascalName}}: constructor', function constructorTest(t){
   var view = createView()
 
   t.equal(
@@ -26,7 +26,7 @@ test('Step: {{PascalName}}: constructor', function(t){
   t.end()
 })
 
-test('Step: {{PascalName}}#bindEvents', function (t){
+test('Step: {{PascalName}}#bindEvents', function bindEventsTest(t){
   var view = createView()
     , fn = view.bindEvents
 
@@ -48,7 +48,7 @@ test('Step: {{PascalName}}#bindEvents', function (t){
   t.end()
 })
 
-test('Step: {{PascalName}}#beforeInit', function(t){
+test('Step: {{PascalName}}#beforeInit', function beforeInitTest(t){
   var view = createView()
     , fn = view.beforeInit
     , options = defaultOptions


### PR DESCRIPTION
Updated `Pane#beforeInit` test so it invokes `fn` (aka `view.beforeInit`) with `defaultOptions` instead of `options`. Now this test is aligned with the tests for the Step and for the component.

Gave anonymous callback functions in the tests names.