### PR TITLE
Style gripe, but also...

### DIFF
--- a/backbone-component-template/index.js
+++ b/backbone-component-template/index.js
@@ -11,9 +11,8 @@ var Base = require('ribcage-view')
       return _.extend(this.serialize(), this.getAttributes({derived: true}))
     }
   })
-  , {{PascalName}}
 
-{{PascalName}} = Base.extend({
+var {{PascalName}} = Base.extend({
 
   template: require('./template.html.hbs')
 

--- a/backbone-pane-template/index.js
+++ b/backbone-pane-template/index.js
@@ -15,9 +15,8 @@ var Base = require('ribcage-view')
       return _.extend(this.serialize(), this.getAttributes({derived: true}))
     }
   })
-  , {{PascalName}}Pane
 
-{{PascalName}}Pane = Base.extend({
+var {{PascalName}}Pane = Base.extend({
 
   className: '{{camelName}}Pane'
 


### PR DESCRIPTION
There *is* a technical point to this!
We're going to adopt ES6. These will be `const`s. As far as I can tell, you can't init an empty `const` and then assign to it later.

So this is more inline with the direction we'll moving in. Might as well get on board now :D