### PR TITLE
Fix error on success

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ribcage-gen
 ===========
 
-A generator script for ribcage components
-
+A generator script for ribcage components. Defaults to a ribcage (ie - backbone) view. Alternatives are ribcage pane/step component or a react component (That's somewhat out of date. Beware)
 
 ## Install
 
@@ -14,8 +13,10 @@ npm install -g ribcage-gen
 
 ```sh
 ribcage-gen <name>
+ribcage-gen -t react <name>
+ribcage-gen -t pane <name>
 ```
 
 Name should be a dash separated string.
 
-Check out the `component-template/` for an example of the output.
+Check out the `backbone-component-template/` for an example of the output.

--- a/bin/rib.js
+++ b/bin/rib.js
@@ -5,6 +5,6 @@ var gen = require('../index')
   , argv = require('minimist')(process.argv.slice(2))
   , type = argv.t || argv.type || 'backbone'
 
-gen({target: argv._[0], type: type}, function (names) {
-  console.log('created the ' + names.PascalName + ' component')
+gen({target: argv._[0], type: type}, function (context) {
+  console.log('created the ' + context.names.PascalName + ' component')
 })

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (options, cb) {
       }
     }
   , successCallback = function successCallback (){
-    cb(opts.context)
+      cb(opts.context)
   }
 
   hbsDir(opts, successCallback)

--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ module.exports = function (options, cb) {
       , name: name
       }
     }
+  , successCallback = function successCallback (){
+    cb(opts.context)
+  }
 
-  hbsDir(opts, cb)
+  hbsDir(opts, successCallback)
 }


### PR DESCRIPTION
Succesful generation of a component was resulting in an error: the success callback expected the name of the component to be be passed, which wasn't happening. 

Also, updated the README, fwiw.