### PR TITLE
add constructor to react template

### DIFF
--- a/react-component-template/index.jsx
+++ b/react-component-template/index.jsx
@@ -4,6 +4,16 @@ const {shouldComponentUpdate} = addons.PureRenderMixin
 const namespace = '{{camelName}}'
 
 export default class {{PascalName}} extends Component {
+  constructor (props) {
+    super(props)
+    // initialize state values
+    this.state = {}
+
+    // bind your custom methods here (instead of render for example)
+    // example:
+    // this._handleSomething = this._handleSomething.bind(this)
+  }
+
   // use the pure-render mixin without the mixin. This allows us to use es6
   // classes and avoid "magic" code. NOTE: if this component is used directly
   // by react-router, you should delete it, otherwise, the <Link> component will


### PR DESCRIPTION
A lot of folks need to initialize `state` with values, so this will make it more clear to users how to do that. 

Binding of custom methods should be done in the `constructor` instead of the `render` method.  This is what the React team recommends. Check out Step 3 of this this document for more information:
http://www.newmediacampaigns.com/blog/refactoring-react-components-to-es6-classes